### PR TITLE
Add Docker Compose support with MongoDB and Redis integration

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,6 @@
+cat <<EOF > .env.docker
+PORT=3000
+MONGO_URL=mongodb://mongo:27017/uncss
+REDIS_HOST=redis
+REDIS_PORT=6379
+EOF

--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ yarn run build
 yarn run deploy
 ```
 
+## 🐳 Docker Deployment
+#### You can easily run this project using Docker and Docker Compose.
+
+🔧 Requirements
+-Docker
+-Docker Compose
+
+📦 Steps
+```bash
+# Clone the repository
+git clone https://github.com/pajasevi/UnCSS-Online.git
+cd UnCSS-Online
+
+# Create environment file
+cp .env.docker .env  # optional; used only for Docker
+
+# Build and run containers
+docker-compose up -d --build
+```
 
 ## License
 Distributed under the MIT license. See [LICENSE](LICENSE) for more information.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  uncss:
+    build: .
+    container_name: uncss
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    depends_on:
+      - mongo
+      - redis
+    restart: unless-stopped
+
+  mongo:
+    image: mongo:4.4
+    container_name: uncss_mongo
+    restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+
+  redis:
+    image: redis:alpine
+    container_name: uncss_redis
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+
+volumes:
+  mongo-data:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "3000:3000"
     env_file:
-      - .env
+      - .env.docker
     depends_on:
       - mongo
       - redis


### PR DESCRIPTION
This pull request adds Docker support to the UnCSS-Online project, allowing the application to be easily deployed using Docker Compose.

### What's Included:
- `docker-compose.yml` to orchestrate app, MongoDB, and Redis containers
- `.env.docker` with default environment variables for Docker use
- Updated `Dockerfile` using Node.js 18.x (compatible with Next.js 14)
- New section in `README.md` with step-by-step Docker deployment instructions

### Why:
- Simplifies setup for new users
- Isolates dependencies
- Makes deployment consistent and production-friendly

This does not interfere with the existing `.env` file or development workflow.

Let me know if you'd like `.env.docker` renamed or scoped differently.
